### PR TITLE
Add logger to dependency injection

### DIFF
--- a/drush.services.yml
+++ b/drush.services.yml
@@ -7,5 +7,6 @@ services:
       - '@features_generator'
       - '@config_update.config_diff'
       - '@config.storage'
+      - '@logger.channel.default'
     tags:
       - { name: drush.command }

--- a/src/Commands/FeaturesCommands.php
+++ b/src/Commands/FeaturesCommands.php
@@ -15,6 +15,7 @@ use Drupal\features\Plugin\FeaturesGeneration\FeaturesGenerationWrite;
 use Drush\Commands\DrushCommands;
 use Drush\Exceptions\UserAbortException;
 use Drush\Utils\StringUtils;
+use Psr\Log\LoggerInterface;
 
 /**
  * Drush commands for Features.
@@ -90,6 +91,13 @@ class FeaturesCommands extends DrushCommands {
   protected $configStorage;
 
   /**
+   * A logger instance.
+   *
+   * @var \Psr\Log\LoggerInterface
+   */
+  protected $logger;
+
+  /**
    * FeaturesCommands constructor.
    *
    * @param \Drupal\features\FeaturesAssignerInterface $assigner
@@ -102,13 +110,16 @@ class FeaturesCommands extends DrushCommands {
    *   The config_update.config_diff service.
    * @param \Drupal\Core\Config\StorageInterface $configStorage
    *   The config.storage service.
+   * @param \Psr\Log\LoggerInterface $logger
+   *   A logger instance.
    */
   public function __construct(
     FeaturesAssignerInterface $assigner,
     FeaturesManagerInterface $manager,
     FeaturesGeneratorInterface $generator,
     ConfigDiffInterface $configDiff,
-    StorageInterface $configStorage
+    StorageInterface $configStorage,
+    LoggerInterface $logger
   ) {
     parent::__construct();
     $this->assigner = $assigner;
@@ -116,6 +127,7 @@ class FeaturesCommands extends DrushCommands {
     $this->configStorage = $configStorage;
     $this->generator = $generator;
     $this->manager = $manager;
+    $this->logger = $logger;
   }
 
   /**


### PR DESCRIPTION
Suite au merge de DRU-367 de Pierre et qui est arrivé sur ton travail sur D8.4 via un rebase develop, j'ai dû remplacer un `drush_features_import_all()` par un `\Drupal::service('features.commands')->importAll();`

J'ai alors découvert un souci sur le logger non injecté.